### PR TITLE
Add MathField to the onChange function

### DIFF
--- a/examples/src/script.js
+++ b/examples/src/script.js
@@ -15,6 +15,7 @@ class App extends React.Component {
 
     this.state = {
       latex: initialLatex,
+      text: '',
     }
 
     this.mathQuillEl = null
@@ -31,9 +32,12 @@ class App extends React.Component {
         <MathQuill
           className="mathquill-example-field"
           latex={this.state.latex}
-          onChange={latex => {
-            console.log('Math field changed:', latex)
-            this.setState({ latex })
+          onChange={mathField => {
+            const latex = mathField.latex()
+            const text = mathField.text()
+            console.log('latex changed:', latex)
+            console.log('text changed:', text)
+            this.setState({ latex, text })
           }}
           mathquillDidMount={el => {
             this.mathQuillEl = el
@@ -43,10 +47,14 @@ class App extends React.Component {
           <span>Raw latex:</span>
           <span className="result-latex">{this.state.latex}</span>
         </div>
+        <div className="result-container">
+          <span>Raw text:</span>
+          <span className="result-latex">{this.state.text}</span>
+        </div>
         <button onClick={this.resetField}>Reset field</button>
       </div>
     )
   }
 }
 
-ReactDOM.render(<App />, document.getElementById('app'))
+ReactDOM.render(<App/>, document.getElementById('app'))

--- a/src/Component.js
+++ b/src/Component.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { MathQuill, MQ } from './mathquill-loader'
+import { MathQuill } from './mathquill-loader'
 
 class MathQuillComponent extends React.Component {
   constructor(props) {
@@ -32,7 +32,7 @@ class MathQuillComponent extends React.Component {
         return
       }
       if (this.props.onChange) {
-        this.props.onChange(mathField.latex())
+        this.props.onChange(mathField)
       }
     }
 


### PR DESCRIPTION
In this PR 

- Change the onChange signature to accept mathField instead of mathField.latex(), in my case I needed the mathField.text() not .latex() so it's better to send the enter mathField and let the consumer decide which function he needs.

- Change the example code to show both .latex() and .text() to show the difference between them.