### PR TITLE
Add maxDepth to the config type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ declare module 'react-mathquill' {
       edit?: (mathField: MathField) => void
       enter?: (mathField: MathField) => void
     }
+    maxDepth?: number
   }
 
   export enum Direction {


### PR DESCRIPTION
This is missing from the new types that were added in 0.2.3 but is still a valid config options:

http://docs.mathquill.com/en/latest/Config/#maxdepth