### PR TITLE
Move react into peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "@edtr-io/mathquill": "^0.11.0",
     "jquery": "^3.5.1",
-    "prop-types": "^15.7.2",
+    "prop-types": "^15.7.2"
+  },
+  "peerDependencies": {
     "react": "^16.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This avoids [Invalid Hook Call Warning](https://reactjs.org/warnings/invalid-hook-call-warning.html). 

When building a react app, and using `react-mathquill` as a dependency, there will be two react instances and react will complain when using hooks. See above link. 
Solution is to move the `react-mathquil`'s react dependency into peerDependency so that there will be only a single instance.