### PR TITLE
Change div wrapper to span in order to work inside buttons

### DIFF
--- a/src/StaticMathField.js
+++ b/src/StaticMathField.js
@@ -24,7 +24,7 @@ class StaticMathField extends React.Component {
     const { mathquillDidMount, children, ...otherProps } = this.props
 
     return (
-      <div
+      <span
         {...otherProps}
         ref={x => {
           this.element = x
@@ -32,7 +32,7 @@ class StaticMathField extends React.Component {
         }}
       >
         {children}
-      </div>
+      </span>
     )
   }
 }


### PR DESCRIPTION
Hey,
Thank you for creating this wrapper. Works great!

I have a use case where I have to put a static math field inside a button, but since the wrapper of the StaticMathField is div, I get unexpected behaviour. Also, divs are not allowed to be inside buttons: https://stackoverflow.com/questions/12982269/is-it-semantically-incorrect-to-put-a-div-or-span-inside-of-a-button