### PR TITLE
Fix state closure issue

### DIFF
--- a/src/EditableMathField.js
+++ b/src/EditableMathField.js
@@ -12,7 +12,13 @@ const EditableMathField = ({
   // MathQuill fire 2 edit events on startup.
   const ignoreEditEvents = useRef(2)
   const mathField = useRef(null)
-  const wrapperElement = useRef(null)
+  const wrapperElement = useRef(null);
+
+  // This is required to prevent state closure over the onChange function
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange])
 
   // Setup MathQuill on the wrapperElement
   useEffect(() => {
@@ -37,7 +43,7 @@ const EditableMathField = ({
       if (ignoreEditEvents.current > 0) {
         ignoreEditEvents.current -= 1
       } else {
-        if (onChange) onChange(mathField)
+        if (onChangeRef.current) onChangeRef.current(mathField)
       }
     }
 


### PR DESCRIPTION
If the value of onChange changes but latex doesn't, then onChange will be outdated and the component will call the wrong function. This leads to hard-to-debug outdated state issues for users of this package.

I fixed this using refs; when onChange changes, it will update the onChange ref.

I could NOT get the package to compile/test on my machine due to webpack issues, please test it yourself before deploying. Nothing should be different except for the state closure