### PR TITLE
Relax `react` requirement to v16.8-18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-mathquill",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-mathquill",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.8",
@@ -35,7 +35,7 @@
         "webpack-dev-server": "^4.3.1"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^16.8 || ^17.0 || ^18.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^16.8 || ^17.0 || ^18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
This `react-mathquill` package only uses the following exports from the peer React package:
- `useEffect`
- `useLayoutEffect`
- `useRef`
- `useState` (only used in `examples/`, not implementation)

These exports are all available in React as of v16.8.0 when hooks were first introduced and they have behaved fairly consistently since then. This seems like sufficient reason to relax the version requirements for the `react` peer dependency.

An example use case that benefits from this widened support allows one to upgrade `react` from v16.8.0 to v18.2.0 without having to update this package at the same time, shrinking the surface area of change that needs to happen all at once.