### PR TITLE
Update React peer dependency to support React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-mathquill",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-mathquill",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.8",
@@ -35,7 +35,7 @@
         "webpack-dev-server": "^4.3.1"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
This PR updates the peerDependencies section in package.json to include support for React 19, ensuring compatibility with projects using the latest React version.
This change maintains backward compatibility with React 18 while adding support for React 19.
package-lock.json has also been updated accordingly.