### PR TITLE
Bump version to 1.0.4 for React 19 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-mathquill",
-  "version": "1.1.0",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-mathquill",
-      "version": "1.1.0",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-mathquill",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-mathquill",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mathquill",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "React component wrapper for Mathquill",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mathquill",
-  "version": "1.1.0",
+  "version": "1.0.4",
   "description": "React component wrapper for Mathquill",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
### Summary
This PR updates the package version from `1.0.3` to `1.0.4` to release the previously merged change adding React 19 to `peerDependencies`.

### Context
The peer dependency update was merged in PR https://github.com/viktorstrate/react-mathquill/pull/65, but the version bump was missed.

### Notes
- No functional changes are included in this PR — this is only a version update for publishing.
